### PR TITLE
feat: solana support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redstone"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 authors = ["RedStone <https://redstone.finance>"]
 description = "A Rust implementation of deserializing&decrypting RedStone payload"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ default = ["pure"]
 pure = ["primitive-types"]
 
 # An extension for Casper network
-network_casper = []
+network_casper = ["casper-contract/wee_alloc", "casper-types"]
 
 # An extension for Radix network
-network_radix = []
+network_radix = ["radix-common", "scrypto"]
 
 # An extension for debug-printing of messages in the Casper extension. Not supported by Casper Contracts deployed to the network.
-casper_debug = ["print_debug"]
+casper_debug = ["print_debug", "casper-contract/test-support"]
 
 # An extension for debug-printing of messages.
 print_debug = []
@@ -27,28 +27,29 @@ print_debug = []
 crypto_secp256k1 = ["secp256k1/recovery", "secp256k1/lowmemory", "secp256k1/alloc"]
 
 # A variant of decrypting the message-signers using k256 library. Cheaper during contract deployment.
-crypto_k256 = []
+crypto_k256 = ["k256/alloc", "k256/sha256", "k256/ecdsa"]
+
+# A variant of decrypting the message-signers using Radix library.
+crypto_radix = ["scrypto", "radix-common"]
 
 # A variant of decrypting the message-signers using Solana library.
 crypto_solana = ["anchor-lang"]
-
-# A variant of decrypting the message-signers using Radix library.
-crypto_radix = []
 
 # A set of helpers for testing & offline usage.
 helpers = ["hex/serde", "hex/alloc"]
 
 [dependencies]
-#casper-contract = { version = "^4.0.0", default-features = false, features = [], optional = true }
-#casper-types = { version = "^4.0.2", default-features = false, features = [], optional = true }
-#radix-common = { version = "^1.3.0", default-features = false, features = [], optional = true }
-#scrypto = { version = "^1.3.0", optional = true }
+casper-contract = { version = "^4.0.0", default-features = false, features = [], optional = true }
+casper-types = { version = "^4.0.2", default-features = false, features = [], optional = true }
+radix-common = { version = "^1.3.0", default-features = false, features = [], optional = true }
+scrypto = { version = "^1.3.0", optional = true }
 sha3 = { version = "^0.10.8", default-features = false, features = ["asm"] }
-#k256 = { version = "^0.13.4", default-features = false, features = [], optional = true }
+k256 = { version = "^0.13.4", default-features = false, features = [], optional = true }
 secp256k1 = { version = "^0.29.1", default-features = false, features = [], optional = true }
 hex = { version = "^0.4.3", default-features = false, features = [], optional = true }
 primitive-types = { version = "^0.13.1", optional = true }
-anchor-lang = { version = "^0.30.1", optional = true, default-features = false }
+anchor-lang = { git = "https://github.com/coral-xyz/anchor", rev = "a7a23eea", optional = true, default-features = false }
+
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "^0.2.15", default-features = false, features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redstone"
-version = "1.3.0"
+version = "1.3.0-pre"
 edition = "2021"
 authors = ["RedStone <https://redstone.finance>"]
 description = "A Rust implementation of deserializing&decrypting RedStone payload"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ default = ["pure"]
 pure = ["primitive-types"]
 
 # An extension for Casper network
-network_casper = ["casper-contract/wee_alloc", "casper-types"]
+network_casper = []
 
 # An extension for Radix network
-network_radix = ["radix-common", "scrypto"]
+network_radix = []
 
 # An extension for debug-printing of messages in the Casper extension. Not supported by Casper Contracts deployed to the network.
-casper_debug = ["print_debug", "casper-contract/test-support"]
+casper_debug = ["print_debug"]
 
 # An extension for debug-printing of messages.
 print_debug = []
@@ -27,24 +27,28 @@ print_debug = []
 crypto_secp256k1 = ["secp256k1/recovery", "secp256k1/lowmemory", "secp256k1/alloc"]
 
 # A variant of decrypting the message-signers using k256 library. Cheaper during contract deployment.
-crypto_k256 = ["k256/alloc", "k256/sha256", "k256/ecdsa"]
+crypto_k256 = []
+
+# A variant of decrypting the message-signers using Solana library.
+crypto_solana = ["anchor-lang"]
 
 # A variant of decrypting the message-signers using Radix library.
-crypto_radix = ["scrypto", "radix-common"]
+crypto_radix = []
 
 # A set of helpers for testing & offline usage.
 helpers = ["hex/serde", "hex/alloc"]
 
 [dependencies]
-casper-contract = { version = "^4.0.0", default-features = false, features = [], optional = true }
-casper-types = { version = "^4.0.2", default-features = false, features = [], optional = true }
-radix-common = { version = "^1.3.0", default-features = false, features = [], optional = true }
-scrypto = { version = "^1.3.0", optional = true }
+#casper-contract = { version = "^4.0.0", default-features = false, features = [], optional = true }
+#casper-types = { version = "^4.0.2", default-features = false, features = [], optional = true }
+#radix-common = { version = "^1.3.0", default-features = false, features = [], optional = true }
+#scrypto = { version = "^1.3.0", optional = true }
 sha3 = { version = "^0.10.8", default-features = false, features = ["asm"] }
-k256 = { version = "^0.13.4", default-features = false, features = [], optional = true }
+#k256 = { version = "^0.13.4", default-features = false, features = [], optional = true }
 secp256k1 = { version = "^0.29.1", default-features = false, features = [], optional = true }
 hex = { version = "^0.4.3", default-features = false, features = [], optional = true }
 primitive-types = { version = "^0.13.1", optional = true }
+anchor-lang = { version = "^0.30.1", optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "^0.2.15", default-features = false, features = ["js"] }

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
 CLIPPY=cargo clippy --release --fix --allow-dirty --allow-staged
 DOC=cargo doc --no-deps --document-private-items
 TEST=RUST_BACKTRACE=full cargo test --features="helpers"
-FEATURE_SETS="crypto_k256" "crypto_k256,network_casper" "crypto_secp256k1" "crypto_secp256k1,network_casper" "crypto_secp256k1,network_radix"
-WASM32_FEATURE_SETS="crypto_radix" "crypto_radix,network_radix"
-
+FEATURE_SETS="crypto_k256" "crypto_k256,network_casper" "crypto_secp256k1" "crypto_secp256k1,network_casper" "crypto_secp256k1,network_radix" "crypto_solana,pure"
+WASM32_FEATURE_SETS="crypto_radix" "crypto_radix,network_radix" "crypto_solana"
 prepare:
 	@rustup target add wasm32-unknown-unknown
 	cargo install wasm-bindgen-cli wasm-pack

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,4 +1,4 @@
-use crate::network::specific::{Bytes, U256};
+use crate::{network::specific::Bytes, FeedId};
 
 /// Configuration for a RedStone payload processor.
 ///
@@ -21,7 +21,7 @@ pub struct Config {
     /// Identifiers for the data feeds from which values are aggregated.
     ///
     /// Each data feed id is represented by the network-specific `U256` type.
-    pub feed_ids: Vec<U256>,
+    pub feed_ids: Vec<FeedId>,
 
     /// The current block time in timestamp format, used for verifying data timeliness.
     ///

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -20,7 +20,7 @@ pub struct Config {
 
     /// Identifiers for the data feeds from which values are aggregated.
     ///
-    /// Each data feed id is represented by the network-specific `U256` type.
+    /// Each data feed id is represented by the `FeedId` type.
     pub feed_ids: Vec<FeedId>,
 
     /// The current block time in timestamp format, used for verifying data timeliness.

--- a/src/core/validator.rs
+++ b/src/core/validator.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     protocol::constants::{MAX_TIMESTAMP_AHEAD_MS, MAX_TIMESTAMP_DELAY_MS},
     utils::filter::FilterSome,
+    FeedId,
 };
 
 /// A trait defining validation operations for data feeds and signers.
@@ -29,7 +30,7 @@ pub(crate) trait Validator {
     /// # Returns
     ///
     /// * `Option<usize>` - The index of the feed if it exists, or `None` if it does not.
-    fn feed_index(&self, feed_id: U256) -> Option<usize>;
+    fn feed_index(&self, feed_id: FeedId) -> Option<usize>;
 
     /// Retrieves the index of a given signer.
     ///
@@ -81,7 +82,7 @@ pub(crate) trait Validator {
 
 impl Validator for Config {
     #[inline]
-    fn feed_index(&self, feed_id: U256) -> Option<usize> {
+    fn feed_index(&self, feed_id: FeedId) -> Option<usize> {
         self.feed_ids.iter().position(|&elt| elt == feed_id)
     }
 
@@ -221,7 +222,7 @@ mod tests {
         Config::test().validate_signer_count_threshold(0, vec![].as_slice());
     }
 
-    #[should_panic(expected = "Insufficient signer count 1 for #1 (BTC)")]
+    #[should_panic(expected = "Insufficient signer count 1 for #1 (BTC")]
     #[test]
     fn test_validate_signer_count_threshold_shorter_list() {
         Config::test().validate_signer_count_threshold(1, vec![1u8].iter_into_opt().as_slice());

--- a/src/crypto/keccak256.rs
+++ b/src/crypto/keccak256.rs
@@ -1,8 +1,10 @@
 use crate::crypto::Keccak256Hash;
 #[cfg(not(all(feature = "crypto_radix", target_arch = "wasm32")))]
+#[cfg(not(feature = "crypto_solana"))]
 use sha3::Digest;
 
 #[cfg(not(all(feature = "crypto_radix", target_arch = "wasm32")))]
+#[cfg(not(feature = "crypto_solana"))]
 pub fn keccak256(data: &[u8]) -> Keccak256Hash {
     sha3::Keccak256::new_with_prefix(data)
         .finalize()
@@ -14,6 +16,11 @@ pub fn keccak256(data: &[u8]) -> Keccak256Hash {
 #[cfg(all(feature = "crypto_radix", target_arch = "wasm32"))]
 pub fn keccak256(data: &[u8]) -> Keccak256Hash {
     scrypto::prelude::CryptoUtils::keccak256_hash(data).0
+}
+
+#[cfg(feature = "crypto_solana")]
+pub fn keccak256(data: &[u8]) -> Keccak256Hash{
+    anchor_lang::solana_program::keccak::hash(data).0
 }
 
 #[cfg(not(all(feature = "crypto_radix", target_arch = "wasm32")))]

--- a/src/crypto/keccak256.rs
+++ b/src/crypto/keccak256.rs
@@ -19,7 +19,7 @@ pub fn keccak256(data: &[u8]) -> Keccak256Hash {
 }
 
 #[cfg(feature = "crypto_solana")]
-pub fn keccak256(data: &[u8]) -> Keccak256Hash{
+pub fn keccak256(data: &[u8]) -> Keccak256Hash {
     anchor_lang::solana_program::keccak::hash(data).0
 }
 

--- a/src/crypto/recover.rs
+++ b/src/crypto/recover.rs
@@ -72,8 +72,7 @@ pub(crate) mod crypto256 {
 #[cfg(all(feature = "crypto_radix", target_arch = "wasm32"))]
 pub(crate) mod crypto256 {
     use super::{EcdsaUncompressedPublicKey, Keccak256Hash, Secp256SigRs};
-    use crate::network::assert::Unwrap;
-    use crate::network::error::Error;
+    use crate::network::{assert::Unwrap, error::Error};
     use radix_common::crypto::{Hash, IsHash, Secp256k1Signature};
     use scrypto::crypto_utils::CryptoUtils;
 
@@ -105,7 +104,8 @@ pub(crate) mod crypto256 {
         recovery_byte: u8,
     ) -> EcdsaUncompressedPublicKey {
         let key = secp256k1_recover(&message_hash, recovery_byte, &signature_bytes)
-            .unwrap().0;
+            .unwrap()
+            .0;
         let mut uncompressed_key = [0u8; 65];
         uncompressed_key[0] = 0x04;
         uncompressed_key[1..].copy_from_slice(&key);

--- a/src/helpers/hex.rs
+++ b/src/helpers/hex.rs
@@ -1,6 +1,7 @@
 use crate::{network::specific::Bytes, FeedId};
 use hex::{decode, encode};
-use std::{fs::File, io::Read};
+
+const SAMPLE_PAYLOAD_HEX: &str = include_str!("../.././sample-data/payload.hex");
 
 pub fn hex_to_bytes(hex_str: String) -> Vec<u8> {
     let trimmed_hex = hex_str.trim_start_matches("0x");
@@ -26,15 +27,12 @@ pub fn make_feed_ids(vec: Vec<&str>) -> Vec<FeedId> {
     vec.iter().map(|&s| make_feed_id(s)).collect()
 }
 
-pub fn read_payload_hex(path: &str) -> String {
-    let mut file = File::open(path).unwrap();
-    let mut contents = String::new();
-    file.read_to_string(&mut contents).expect("Read error");
-    contents
+pub fn sample_payload_hex() -> String {
+    SAMPLE_PAYLOAD_HEX.to_string()
 }
 
-pub fn read_payload_bytes(path: &str) -> Vec<u8> {
-    let contents = read_payload_hex(path);
+pub fn sample_payload_bytes() -> Vec<u8> {
+    let contents = sample_payload_hex();
 
     hex_to_bytes(contents)
 }

--- a/src/helpers/hex.rs
+++ b/src/helpers/hex.rs
@@ -1,7 +1,4 @@
-use crate::network::{
-    from_bytes_repr::FromBytesRepr,
-    specific::{Bytes, U256},
-};
+use crate::{network::specific::Bytes, FeedId};
 use hex::{decode, encode};
 use std::{fs::File, io::Read};
 
@@ -21,11 +18,11 @@ pub fn make_bytes(vec: Vec<&str>, fun: fn(&str) -> String) -> Vec<Bytes> {
         .collect()
 }
 
-pub fn make_feed_id(s: &str) -> U256 {
-    U256::from_bytes_repr(hex_to_bytes(encode(s)))
+pub fn make_feed_id(s: &str) -> FeedId {
+    hex_to_bytes(encode(s)).into()
 }
 
-pub fn make_feed_ids(vec: Vec<&str>) -> Vec<U256> {
+pub fn make_feed_ids(vec: Vec<&str>) -> Vec<FeedId> {
     vec.iter().map(|&s| make_feed_id(s)).collect()
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 //! Different crypto-mechanisms are easily injectable.
 //! The current implementation contains `secp256k1`- and `k256`-based variants.
 
+use network::from_bytes_repr::Sanitized;
+
 pub mod core;
 mod crypto;
 pub mod network;
@@ -14,3 +16,19 @@ mod utils;
 
 #[cfg(feature = "helpers")]
 pub mod helpers;
+
+/// Type describing feed ids.
+/// We expect feed id to be byte string lik b"EUR"
+/// converted to bytearray and padded with zeros to the right.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct FeedId(pub [u8; 32]);
+
+impl From<Vec<u8>> for FeedId {
+    fn from(value: Vec<u8>) -> Self {
+        let value = value.sanitized();
+        let mut buff = [0; 32];
+        buff[0..value.len()].copy_from_slice(&value);
+
+        Self(buff)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ mod utils;
 pub mod helpers;
 
 /// Type describing feed ids.
-/// We expect feed id to be byte string lik b"EUR"
-/// converted to bytearray and padded with zeros to the right.
+/// We expect FeedId to be byte string like b"EUR"
+/// converted to bytearray and padded with zeroes to the right.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct FeedId(pub [u8; 32]);
 

--- a/src/network/as_str.rs
+++ b/src/network/as_str.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use crate::network::specific::U256;
+use crate::{network::specific::U256, utils::trim_zeros::TrimZeros, FeedId};
 use alloc::{format, string::String};
 
 pub trait AsHexStr {
@@ -42,6 +42,12 @@ impl AsHexStr for U256 {
     }
 }
 
+impl AsAsciiStr for FeedId {
+    fn as_ascii_str(&self) -> String {
+        self.0.to_vec().trim_zeros().as_ascii_str()
+    }
+}
+
 impl AsHexStr for Vec<u8> {
     fn as_hex_str(&self) -> String {
         self.as_slice().as_hex_str()
@@ -67,6 +73,12 @@ impl AsAsciiStr for &[u8] {
 impl AsAsciiStr for Vec<u8> {
     fn as_ascii_str(&self) -> String {
         self.as_slice().as_ascii_str()
+    }
+}
+
+impl AsHexStr for FeedId {
+    fn as_hex_str(&self) -> String {
+        self.0.as_slice().as_hex_str()
     }
 }
 

--- a/src/network/error.rs
+++ b/src/network/error.rs
@@ -1,6 +1,9 @@
-use crate::network::{
-    as_str::{AsAsciiStr, AsHexStr},
-    specific::U256,
+use crate::{
+    network::{
+        as_str::{AsAsciiStr, AsHexStr},
+        specific::U256,
+    },
+    FeedId,
 };
 use std::fmt::{Debug, Display, Formatter};
 
@@ -61,7 +64,7 @@ pub enum Error {
     ///
     /// This variant includes the current number of signers, the required threshold, and
     /// potentially a feed_id related to the operation that failed due to insufficient signers.
-    InsufficientSignerCount(usize, usize, U256),
+    InsufficientSignerCount(usize, usize, FeedId),
 
     /// Used when a timestamp is older than allowed by the processor logic.
     ///
@@ -87,7 +90,7 @@ impl Error {
         Error::ContractError(Box::new(value))
     }
 
-    pub(crate) fn code(&self) -> u16 {
+    pub fn code(&self) -> u16 {
         match self {
             Error::ContractError(boxed) => boxed.code() as u16,
             Error::NumberOverflow(_) => 509,

--- a/src/network/print_debug.rs
+++ b/src/network/print_debug.rs
@@ -3,9 +3,11 @@ extern crate alloc;
 #[macro_export]
 macro_rules! print_debug {
     ($fmt:expr) => {
+        #[cfg(feature = "print_debug")]
         $crate::network::specific::print(format!($fmt))
     };
     ($fmt:expr, $($args:tt)*) => {
+        #[cfg(feature = "print_debug")]
         $crate::network::specific::print(format!($fmt, $($args)*))
     };
 }

--- a/src/protocol/data_package.rs
+++ b/src/protocol/data_package.rs
@@ -72,7 +72,7 @@ impl Debug for DataPackage {
 mod tests {
     use crate::{
         helpers::hex::hex_to_bytes,
-        network::{from_bytes_repr::FromBytesRepr, specific::U256},
+        network::specific::U256,
         protocol::{
             constants::{
                 DATA_FEED_ID_BS, DATA_POINTS_COUNT_BS, DATA_POINT_VALUE_BYTE_SIZE_BS, SIGNATURE_BS,
@@ -207,7 +207,7 @@ mod tests {
     fn verify_data_package(result: DataPackage, expected_value: u128, signer_address: &str) {
         let data_package = DataPackage {
             data_points: vec![DataPoint {
-                feed_id: U256::from_bytes_repr(hex_to_bytes(DATA_PACKAGE_BYTES_1[..6].into())),
+                feed_id: hex_to_bytes(DATA_PACKAGE_BYTES_1[..6].into()).into(),
                 value: U256::from(expected_value),
             }],
             timestamp: 1707144580000,

--- a/src/protocol/data_point.rs
+++ b/src/protocol/data_point.rs
@@ -3,17 +3,17 @@ use crate::{
         as_str::{AsAsciiStr, AsHexStr},
         assert::Assert,
         error::Error,
-        from_bytes_repr::FromBytesRepr,
         specific::U256,
     },
     protocol::constants::DATA_FEED_ID_BS,
-    utils::{trim::Trim, trim_zeros::TrimZeros},
+    utils::trim::Trim,
+    FeedId,
 };
 use std::fmt::{Debug, Formatter};
 
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct DataPoint {
-    pub(crate) feed_id: U256,
+    pub(crate) feed_id: FeedId,
     pub(crate) value: U256,
 }
 
@@ -36,12 +36,9 @@ pub(crate) fn trim_data_points(
 
 fn trim_data_point(payload: &mut Vec<u8>, value_size: usize) -> DataPoint {
     let value = payload.trim_end(value_size);
-    let feed_id: Vec<u8> = payload.trim_end(DATA_FEED_ID_BS);
+    let feed_id = payload.trim_end(DATA_FEED_ID_BS);
 
-    DataPoint {
-        value,
-        feed_id: U256::from_bytes_repr(feed_id.trim_zeros()),
-    }
+    DataPoint { value, feed_id }
 }
 
 impl Debug for DataPoint {
@@ -61,10 +58,7 @@ impl Debug for DataPoint {
 mod tests {
     use crate::{
         helpers::hex::hex_to_bytes,
-        network::{
-            from_bytes_repr::FromBytesRepr,
-            specific::{U256, VALUE_SIZE},
-        },
+        network::specific::{U256, VALUE_SIZE},
         protocol::{
             constants::DATA_FEED_ID_BS,
             data_point::{trim_data_point, trim_data_points, DataPoint},
@@ -152,7 +146,7 @@ mod tests {
 
         let data_point = DataPoint {
             value: expected_value,
-            feed_id: U256::from_bytes_repr(hex_to_bytes(DATA_POINT_BYTES_TAIL[..6].to_string())),
+            feed_id: hex_to_bytes(DATA_POINT_BYTES_TAIL[..6].to_string()).into(),
         };
 
         assert_eq!(result, data_point);

--- a/src/protocol/payload.rs
+++ b/src/protocol/payload.rs
@@ -46,7 +46,7 @@ fn trim_metadata(payload: &mut Vec<u8>) -> usize {
 #[cfg(test)]
 mod tests {
     use crate::{
-        helpers::hex::{hex_to_bytes, read_payload_bytes, read_payload_hex},
+        helpers::hex::{hex_to_bytes, sample_payload_bytes, sample_payload_hex},
         protocol::{
             constants::REDSTONE_MARKER_BS,
             payload::{trim_metadata, trim_payload, Payload},
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn test_trim_payload() {
-        let payload_hex = read_payload_bytes("./sample-data/payload.hex");
+        let payload_hex = sample_payload_bytes();
 
         let mut bytes = payload_hex[..payload_hex.len() - REDSTONE_MARKER_BS].into();
         let payload = trim_payload(&mut bytes);
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn test_make_payload() {
-        let mut payload_hex = read_payload_bytes("./sample-data/payload.hex");
+        let mut payload_hex = sample_payload_bytes();
         let payload = Payload::make(&mut payload_hex);
 
         assert_eq!(payload.data_packages.len(), 15);
@@ -99,7 +99,7 @@ mod tests {
     #[should_panic(expected = "Non empty payload remainder: 12")]
     #[test]
     fn test_make_payload_with_prefix() {
-        let payload_hex = read_payload_hex("./sample-data/payload.hex");
+        let payload_hex = sample_payload_hex();
         let mut bytes = hex_to_bytes("12".to_owned() + &payload_hex);
         let payload = Payload::make(&mut bytes);
 

--- a/src/utils/trim.rs
+++ b/src/utils/trim.rs
@@ -1,5 +1,6 @@
-use crate::network::{
-    assert::Unwrap, error::Error, from_bytes_repr::FromBytesRepr, specific::U256,
+use crate::{
+    network::{assert::Unwrap, error::Error, from_bytes_repr::FromBytesRepr, specific::U256},
+    FeedId,
 };
 
 pub trait Trim<T>
@@ -16,6 +17,17 @@ impl Trim<Vec<u8>> for Vec<u8> {
         } else {
             self.split_off(self.len() - len)
         }
+    }
+}
+
+impl Trim<FeedId> for Vec<u8> {
+    fn trim_end(&mut self, len: usize) -> FeedId {
+        let v: Vec<_> = self.trim_end(len);
+
+        let mut buff = [0; 32];
+
+        buff.copy_from_slice(&v);
+        FeedId(buff)
     }
 }
 

--- a/src/utils/trim.rs
+++ b/src/utils/trim.rs
@@ -24,10 +24,7 @@ impl Trim<FeedId> for Vec<u8> {
     fn trim_end(&mut self, len: usize) -> FeedId {
         let v: Vec<_> = self.trim_end(len);
 
-        let mut buff = [0; 32];
-
-        buff.copy_from_slice(&v);
-        FeedId(buff)
+        v.into()
     }
 }
 


### PR DESCRIPTION
* New type FeedId so we can encapsulate the logic behind it and help users of sdk see what we want from it.
* print_debug feature now hides string computations if the feature is not enabled
* solana support added
  * with anchor ver taken from latest main commit since there were some dep resolution conflicts with the v0.30