### PR TITLE
Add associated values in mod errors Error.

### DIFF
--- a/crates/redstone/src/contract/verification.rs
+++ b/crates/redstone/src/contract/verification.rs
@@ -74,12 +74,7 @@ pub fn verify_write_timestamp(
                 .add(min_time_between_updates)
                 .is_same_or_after(time_now) =>
         {
-            Err(
-                Error::CurrentUpdateTimestampMustBeGreaterThanLatestUpdateTimestamp(
-                    write_time.add(min_time_between_updates),
-                    time_now,
-                ),
-            )
+            Err(Error::CurrentTimestampMustBeGreaterThanLatestUpdateTimestamp(time_now, write_time))
         }
         _ => Ok(()),
     }
@@ -92,7 +87,7 @@ pub fn verify_package_timestamp(
     new_package_time: TimestampMillis,
 ) -> Result<(), Error> {
     if new_package_time.is_same_or_before(last_package_time) {
-        return Err(Error::PackageTimestampMustBeGreaterThanBefore(
+        return Err(Error::DataTimestampMustBeGreaterThanBefore(
             new_package_time,
             last_package_time,
         ));
@@ -198,9 +193,9 @@ mod tests {
         assert_eq!(
             res,
             Err(
-                Error::CurrentUpdateTimestampMustBeGreaterThanLatestUpdateTimestamp(
+                Error::CurrentTimestampMustBeGreaterThanLatestUpdateTimestamp(
                     999.into(),
-                    999.into()
+                    900.into()
                 )
             )
         );
@@ -218,7 +213,7 @@ mod tests {
         assert_eq!(
             res,
             Err(
-                Error::CurrentUpdateTimestampMustBeGreaterThanLatestUpdateTimestamp(
+                Error::CurrentTimestampMustBeGreaterThanLatestUpdateTimestamp(
                     900.into(),
                     900.into()
                 )
@@ -237,7 +232,7 @@ mod tests {
         let res = verify_trusted_update(901.into(), Some(900.into()), 1.into(), 1.into());
         assert_eq!(
             res,
-            Err(Error::PackageTimestampMustBeGreaterThanBefore(
+            Err(Error::DataTimestampMustBeGreaterThanBefore(
                 1.into(),
                 1.into()
             ))
@@ -247,7 +242,7 @@ mod tests {
             verify_untrusted_update(901.into(), Some(900.into()), 1.into(), 1.into(), 1.into());
         assert_eq!(
             res,
-            Err(Error::PackageTimestampMustBeGreaterThanBefore(
+            Err(Error::DataTimestampMustBeGreaterThanBefore(
                 1.into(),
                 1.into()
             ))

--- a/crates/redstone/src/network/error.rs
+++ b/crates/redstone/src/network/error.rs
@@ -108,14 +108,14 @@ pub enum Error {
     /// Includes FeedId that is reocuring.
     ConfigReocuringFeedId(FeedId),
 
-    /// Indicates that the provided package timestamp is not greater than a previously written package timestamp.
+    /// Indicates that the provided data timestamp is not greater than a previously written package timestamp.
     ///
     /// For the price adapter to accept a new price update, the associated timestamp must be
     /// strictly greater than the timestamp of the last update. This error is raised if a new
     /// timestamp does not meet this criterion, ensuring the chronological integrity of price data.
     ///
     /// Includes the value of a current package timestamp and the timestamp of the previous package.
-    PackageTimestampMustBeGreaterThanBefore(TimestampMillis, TimestampMillis),
+    DataTimestampMustBeGreaterThanBefore(TimestampMillis, TimestampMillis),
 
     /// Indicates that the current update timestamp is not greater than the last update timestamp.
     ///
@@ -125,7 +125,7 @@ pub enum Error {
     /// integrity and consistency of the updates.
     ///
     /// Includes the value of a current update timestamp and the last update timestamp.
-    CurrentUpdateTimestampMustBeGreaterThanLatestUpdateTimestamp(TimestampMillis, TimestampMillis),
+    CurrentTimestampMustBeGreaterThanLatestUpdateTimestamp(TimestampMillis, TimestampMillis),
 }
 
 impl From<CryptoError> for Error {
@@ -155,8 +155,8 @@ impl Error {
             Error::CryptographicError(error) => 700 + error.code(),
             Error::TimestampTooOld(data_package_index, _) => 1000 + *data_package_index as u16,
             Error::TimestampTooFuture(data_package_index, _) => 1050 + *data_package_index as u16,
-            Error::PackageTimestampMustBeGreaterThanBefore(_, _) => 1101,
-            Error::CurrentUpdateTimestampMustBeGreaterThanLatestUpdateTimestamp(_, _) => 1102,
+            Error::DataTimestampMustBeGreaterThanBefore(_, _) => 1101,
+            Error::CurrentTimestampMustBeGreaterThanLatestUpdateTimestamp(_, _) => 1102,
         }
     }
 }
@@ -220,13 +220,13 @@ impl Display for Error {
                     feed_id.as_hex_str()
                 )
             }
-            Error::PackageTimestampMustBeGreaterThanBefore(current, before) => {
+            Error::DataTimestampMustBeGreaterThanBefore(current, before) => {
                 write!(
                     f,
                     "Package timestamp: {current:?} must be greater than package timestamp before: {before:?}"
                 )
             }
-            Error::CurrentUpdateTimestampMustBeGreaterThanLatestUpdateTimestamp(current, last) => {
+            Error::CurrentTimestampMustBeGreaterThanLatestUpdateTimestamp(current, last) => {
                 write!(
                     f,
                     "Current update timestamp: {current:?} must be greater than latest update timestamp: {last:?}"


### PR DESCRIPTION
### Reference

[RDS-1914](https://redstone-team.atlassian.net/browse/RDS-1914) 

Fix Error variant:

 - TimestampMustBeGreaterThanBefore

 - CurrentTimestampMustBeGreaterThanLatestUpdateTimestamp